### PR TITLE
fixes crash loading enter_scores page

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -227,12 +227,10 @@ class HLScoreForm(FlaskForm):
         return
 
     def load_scores(self, match):
-        if match.high_scores.all() is None and match.low_scores.all():
+        if match.high_scores.all() is None and match.low_scores.all() is None:
             return
-        hp = [s.player for s in match.high_scores.group_by(HighScore.player_id).all()]
-        lp = [s.player for s in match.low_scores.group_by(LowScore.player_id).all()]
-        all_p = hp + list(set(lp)-set(hp))
 
+        all_p = match.get_roster()
         diff = len(all_p) - len(self.hl_scores)
 
         if diff > 0:

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -278,7 +278,7 @@ def enter_score(id):
         hl_form.load_scores(match)
 
     return render_template('enter_score.html', title='Enter Scores', 
-        form=form, hl_form=hl_form, match=match, all_matches=all_matches), print('emd')
+        form=form, hl_form=hl_form, match=match, all_matches=all_matches)
 
 
 @bp.route('/player/<nickname>',  methods=['GET', 'POST'])


### PR DESCRIPTION
fixes #43 

Crash was due to a poorly formed query in [forms.py](forms.py#L229). Was apparently ok for SQLite but not Postgres. I simplified the load_scores() function in HLScoreForm using the match.get_roster() function.

Tested and working. Scores can be entered and updated. No crashes
