### PR TITLE
HL score form

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -238,6 +238,11 @@ class EnterScoresForm(FlaskForm):
             f.p2_stars.choices =[('0','0'),('1','1')]
 
     def load_games(self, match):
+        self.match_summary.data = match.match_summary
+        self.food.data = match.food
+        self.win.data = match.win
+        self.overtime.data = match.overtime
+        
         if match.games.all() is None:
             return
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -414,17 +414,17 @@ def enter_score(id):
         new_row = hl_form.hl_scores.append_entry()
         roster_choices = current_roster('ordered')
         new_row.player.choices = [(p.nickname,p.nickname) for p in roster_choices]
-
+        form.load_games(match)
         return render_template('enter_score.html', title='Enter Scores', 
         form=form, hl_form=hl_form, match=match)
 
     if hl_form.rem_btn.data:
         hl_form.hl_scores.pop_entry()
+        form.load_games(match)
         return render_template('enter_score.html', title='Enter Scores', 
         form=form, hl_form=hl_form, match=match)
 
     if hl_form.submit_hl_scores.data and match is not None:
-
         print(hl_form.validate())
         for fieldName, errorMessages in hl_form.errors.items():
             for err in errorMessages:

--- a/app/templates/enter_score.html
+++ b/app/templates/enter_score.html
@@ -44,7 +44,7 @@
 
   <div class="col-md-9">
   {% if match %}
-    <div class="card">
+    <div class="card m-2">
       <h2 class="card-header">Details and game scores</h2>
       <div class="card-body">
       <h3 class="text-center text-muted">{{ match.opponent.name }} {{ match.home_away }} game on {{ match.date.strftime('%Y-%m-%d') }}</h3>
@@ -122,7 +122,7 @@
       </div>
     </div>
 
-    <div id="hl_scores" class="card">
+    <div id="hl_scores" class="card m-2">
       <h2 class="card-header">High and low scores</h2>
       <small class="p-2">Use a <i>*</i> or <i>o</i> to indicate a high score as a big out, e.g. <i>96*</i> or <i>104o</i>.</small>
       <div class="card-body">
@@ -144,8 +144,8 @@
         {% include '_hl_score.html' %}
         {% endfor %}
 
-        {{ wtf.form_field(hl_form.add_btn, button_map={'add_btn': 'primary my-1 btn-sm'}) }}
-        {{ wtf.form_field(hl_form.rem_btn, button_map={'rem_btn': 'secondary my-1 btn-sm'}) }}
+        {{ wtf.form_field(hl_form.add_btn, button_map={'add_btn': 'primary add-btn'}) }}
+        {{ wtf.form_field(hl_form.rem_btn, button_map={'rem_btn': 'secondary add-btn'}) }}
 
         {{ wtf.form_field(hl_form.submit_hl_scores, button_map={'submit_hl_scores': 'primary my-1 btn-block'}) }}
         </form>


### PR DESCRIPTION
fixes #1 and fixes #2 

Loads match detail during HL form editing. Allows more than 12 high or low scores to be entered (just need to add row and select a duplicate player). Players with more than 12 scores will show as two rows when scores are loaded.